### PR TITLE
Issue #12 - proyectos por año

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -19,6 +19,22 @@ source("helper_code/paletas_colores.R")
 
 conicet <- read.csv("data/processed_data.csv") 
 
+conicet <- conicet %>%
+  filter(
+    !is.na(REGION), 
+    !is.na(PROVINCIA), 
+    REGION != "Otra región"
+  )
+
+# 1. Crear el mapa de Región -> Provincia
+prov_region_map <- conicet %>%
+  select(REGION, PROVINCIA) %>%
+  distinct() %>%
+  arrange(REGION, PROVINCIA)
+
+# 2. Crear la lista agrupada (nombrada) para el pickerInput
+lista_provincias_agrupada <- split(prov_region_map$PROVINCIA, prov_region_map$REGION)
+
 #UI---------------------
 ui <- 
   navbarPage("",
@@ -152,16 +168,38 @@ ui <-
                           column(4, leafletOutput("mapa", height = "100vh")),  
                           column(4, 
                                  fluidRow(
-                                   column(12, plotOutput("graficoProyectosRegion", height = "50vh")),  
                                    column(12, 
                                           fluidRow(
-                                            column(12, 
-                                                   shinyWidgets::pickerInput("provincia_filter", "Seleccione una provincia:",
-                                                                             choices = c("Todas", unique(conicet$PROVINCIA)), 
-                                                                             selected = "Todas", 
-                                                                             options = list(`actions-box` = TRUE), 
-                                                                             multiple = TRUE)),  
-                                            column(12, plotOutput("graficoProyectosTiempo", height = "50vh"))   
+                                            column(12,
+                                                   
+                                                   # <--- 1. AÑADIMOS UN SWITCH PARA AGRUPAR/DESAGRUPAR ---->
+                                                   radioButtons("agrupar_grafico",
+                                                                label = "Modo de visualización:",
+                                                                choices = list(
+                                                                  "Total" = TRUE,
+                                                                  "Por Provincia" = FALSE
+                                                                ),
+                                                                selected = TRUE, # Inicia en "Total"
+                                                                inline = TRUE # Los pone en horizontal
+                                                   ),
+                                                   
+                                                   shinyWidgets::pickerInput(
+                                                     "provincia_filter", 
+                                                     "Seleccione una/s provincia/s para ver la cantidad de proyectos según el período seleccionado",
+                                                     choices = lista_provincias_agrupada, 
+                                                     selected = unique(conicet$PROVINCIA), 
+                                                     
+                                                     options = list(
+                                                       `actions-box` = TRUE,
+                                                       `select-all-text` = "Seleccionar Todo",
+                                                       `deselect-all-text` = "Deseleccionar Todo"
+                                                     ), 
+                                                     
+                                                     multiple = TRUE,
+                                                     width = "100%"
+                                                   )
+                                            ),
+                                            column(12, plotOutput("graficoProyectosTiempo", height = "50vh"))
                                           )
                                    )
                                  )
@@ -201,3 +239,4 @@ ui <-
                       )
              )
   )
+


### PR DESCRIPTION
Resuelve issue #12, mejora panel de proyectos por año en provincias.

Debajo listo los cambios que hice: 
-  Agregué una limpieza de datos luego de la carga del df, filtrando NAs en REGION/PROVINCIA y eliminando el grupo "Otra región".
- Creé el objeto lista_provincias_agrupada (una lista split por región) para hacer el gráfico con el desagrageado por provincia.
- (UI) Selector de Provincias (pickerInput). Agregué lista_provincias_agrupada para mostrar provincias anidadas bajo su región.
- (UI) Reemplacé el label por 'Seleccione una/s provincia/s para ver la cantidad de proyectos según el período seleccionado'
- (UI) Traduje los botones y textos de ayuda (select-all-text, deselect-all-text) al español.
- (UI) Agregué radioButtons (inputId = "agrupar_grafico") para seleccionar el tipo de gráfico, con opciones "Total" y "Por Provincia".
- (server) Repliqué la misma lógica de limpieza de datos (filtro de NAs y "Otra región").
- (server) Gráfico (output$graficoProyectosTiempo): El render ahora se divide con un if (input$agrupar_grafico) que reacciona a los radioButtons.
- (server) if: añadí una lógica para verificar las regiones de las provincias seleccionadas. Si es una sola región, la línea toma el color de esa región (colores_regiones); si son múltiples (o ninguna), usa un color neutral ("blue").
- (server) else: El gráfico ahora agrupa los datos por AÑO y PROVINCIA. En ggplot, el aes(color = ...) se asigna a PROVINCIA para generar líneas múltiples (una por provincia) con colores automáticos.